### PR TITLE
fix: törött linkek javítása a Composer dokumentációban

### DIFF
--- a/docs/dokumentacio/hellopack/composer.mdx
+++ b/docs/dokumentacio/hellopack/composer.mdx
@@ -24,7 +24,7 @@ A Composer egy függőségkezelő PHP-hoz. Segítségével parancssorból telep�
 
 ### 1. API token létrehozása
 
-Hozz létre egy API tokent az [API-kulcskészítőben](/dokumentacio/api/api-kulcs-keszito) a hitelesítéshez.
+Hozz létre egy API tokent az [API-kulcskészítőben](https://hellowp.io/hu/helloconsole/hellopack-kozpont/api-creator-v2/) a hitelesítéshez.
 
 ### 2. Token beállítása
 

--- a/docs/tudasbazis/fejlesztoi-eszkozok/composer.mdx
+++ b/docs/tudasbazis/fejlesztoi-eszkozok/composer.mdx
@@ -75,22 +75,22 @@ A Composer különösen hasznos WordPress fejlesztéshez:
 
 ### Ingyenes pluginok és témák
 
-A [WPackagist](/tudasbazis/fejlesztoi-eszkozok/wpackagist) repository lehetővé teszi, hogy a wordpress.org-on elérhető összes ingyenes plugint és témát Composerrel telepítsd.
+A [WPackagist](/docs/tudasbazis/fejlesztoi-eszkozok/wpackagist) repository lehetővé teszi, hogy a wordpress.org-on elérhető összes ingyenes plugint és témát Composerrel telepítsd.
 
 ### Prémium pluginok és témák
 
 A **HelloPack** saját Composer repository-t biztosít a prémium bővítmények és témák telepítéséhez.
 
 :::tip HelloPack Composer integráció
-A HelloPack előfizetéssel elérhető prémium pluginokat és témákat közvetlenül Composerrel telepítheted. Részletes útmutató: [HelloPack Composer dokumentáció](/dokumentacio/hellopack/composer)
+A HelloPack előfizetéssel elérhető prémium pluginokat és témákat közvetlenül Composerrel telepítheted. Részletes útmutató: [HelloPack Composer dokumentáció](/docs/dokumentacio/hellopack/composer)
 :::
 
 ### Modern WordPress boilerplate-ek
 
 Számos modern WordPress fejlesztői keretrendszer épül Composerre:
 
-- [Bedrock](/tudasbazis/fejlesztoi-eszkozok/bedrock) - A Roots csapat modern WordPress boilerplate-je
-- [Acorn](/tudasbazis/fejlesztoi-eszkozok/acorn) - Laravel komponensek WordPress-hez
+- [Bedrock](/docs/tudasbazis/fejlesztoi-eszkozok/bedrock) - A Roots csapat modern WordPress boilerplate-je
+- [Acorn](/docs/tudasbazis/fejlesztoi-eszkozok/acorn) - Laravel komponensek WordPress-hez
 
 ## Példa composer.json
 
@@ -180,5 +180,5 @@ composer config -g http-basic.example.com username password
 
 - [Composer hivatalos dokumentáció](https://getcomposer.org/doc/)
 - [Packagist - PHP Package Repository](https://packagist.org)
-- [WPackagist - WordPress Composer Repository](/tudasbazis/fejlesztoi-eszkozok/wpackagist)
-- [HelloPack Composer](/dokumentacio/hellopack/composer)
+- [WPackagist - WordPress Composer Repository](/docs/tudasbazis/fejlesztoi-eszkozok/wpackagist)
+- [HelloPack Composer](/docs/dokumentacio/hellopack/composer)


### PR DESCRIPTION
## Summary
- API-kulcskészítő link javítása külső URL-re (hellowp.io)
- Belső linkek javítása `/docs/` prefixszel

## Test plan
- [ ] Build futtatása