### PR TITLE
HelloBlog link hozzáadása a footerhez

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -235,6 +235,10 @@ const config = {
                 label: "Kapcsolat",
                 href: "https://hellowp.io/hu/kapcsolat/",
               },
+              {
+                label: "WordPress hírek",
+                href: "https://helloblog.io/hu/",
+              },
             ],
           },
         ],


### PR DESCRIPTION
## Summary
- WordPress hírek link hozzáadása a footer HelloWP szekciójához
- Link: https://helloblog.io/hu/

## Test plan
- [ ] Footer megjelenés ellenőrzése