### PR TITLE
feat: WPEmbed komponens újraírása és hibakeresési dokumentáció frissítése

### DIFF
--- a/docs/tudasbazis/hibaelharitas/wordpress/hibakereses-wordpress-ben.mdx
+++ b/docs/tudasbazis/hibaelharitas/wordpress/hibakereses-wordpress-ben.mdx
@@ -15,11 +15,11 @@ import WPEmbed from "@site/src/components/WPEmbed";
 
 A PHP kód hibakeresése minden projekt része, azonban a WordPress speciális hibakereső rendszerekkel rendelkezik, amelyek egyszerűsítik a folyamatot és szabványosítják a kódot a WordPress alaprendszer, bővítmények és sablonok terén. Ezen az oldalon bemutatjuk a WordPress különböző hibakereső eszközeit, és hogy hogyan lehetsz produktívabb a kódolás során, valamint hogyan lehet javítani a kód általános minőségét és interoperabilitását.
 
-A nem programozóknak vagy általános felhasználóknak ezeket az opciókat használhatják az hibákról részletes információk megjelenítéséhez.
+A nem programozóknak vagy általános felhasználóknak ezeket az opciókat használhatják a hibákról részletes információk megjelenítéséhez.
 
 ## Példa wp-config.php a hibakereséshez
 
-```php config.php
+```php wp-config.php
 // WP_DEBUG mód engedélyezése
 define( 'WP_DEBUG', true );
 
@@ -36,20 +36,20 @@ define( 'SCRIPT_DEBUG', true );
 ```
 
 :::note
-MEGJEGYZÉS: Ezt be kell szúrni a wp-config.php fájlban található /_ That's all, stop editing! Happy blogging. _/ SOR ELŐTT.
+MEGJEGYZÉS: Ezt be kell szúrni a wp-config.php fájlban található /* That's all, stop editing! Happy publishing. */ SOR ELŐTT.
 :::
 
 ## WP_DEBUG
 
 A `WP_DEBUG` egy PHP állandó (állandó globális változó), amelyet használhatunk a WordPress összes részén a "debug" mód aktiválásához. Alapértelmezésben hamisnak tekinthető, és általában az `wp-config.php` fájlban van beállítva true értékre a WordPress fejlesztési verzióiban.
 
-```php config.php
+```php wp-config.php
 // WP_DEBUG mód engedélyezése
 define( 'WP_DEBUG', true );
 
 ```
 
-```php config.php
+```php wp-config.php
 // WP_DEBUG mód letiltása
 define( 'WP_DEBUG', false );
 
@@ -77,7 +77,7 @@ Fontos megjegyezni, hogy ezzel a beállítással lehetővé válik a naplófájl
 
 Amikor az értéke igazra (`TRUE`) van állítva, a napló a tartalomkönyvtárban (általában `wp-content/debug.log`) lesz mentve a webhely fájlrendszerében. Egyébként meg lehet adni egy érvényes fájl elérési útvonalát, hogy máshova lehessen menteni a fájlt.
 
-```php config.php
+```php wp-config.php
 define( 'WP_DEBUG_LOG', true );
 // - vagy -
 define( 'WP_DEBUG_LOG', '/tmp/wp-errors.log' );
@@ -91,7 +91,7 @@ A `WP_DEBUG_LOG` funkció használatához a WP_DEBUG-nak (`TRUE`) be kell lennie
 
 A `WP_DEBUG_DISPLAY` egy másik kiegészítője a `WP_DEBUG`-nak, amely szabályozza, hogy a hibakereső üzenetek megjelenjenek-e az oldal HTML-jében vagy sem. Az alapértelmezett érték "TRUE", ami megjeleníti a hibákat és figyelmeztetéseket, amint létrejönnek. Ha ezt az értéket hamisra ("FALSE") állítod, akkor az összes hibát elrejti. Ezt együtt kell használni a `WP_DEBUG_LOG` funkcióval, hogy a hibákat később áttekinthesd.
 
-```php config.php
+```php wp-config.php
 define( 'WP_DEBUG_DISPLAY', false );
 ```
 
@@ -103,7 +103,7 @@ A `WP_DEBUG_DISPLAY` funkció használatához a `WP_DEBUG`-nak (true) be kell le
 
 A `SCRIPT_DEBUG` egy kapcsolódó állandó, amely arra kényszeríti a WordPress-t, hogy a core CSS- és JavaScript fájljainak "fejlesztői" verzióját használja a normál, tömörített verziók helyett. Ez hasznos lehet, ha teszteled a beépített .js vagy .css fájlok módosításait. Az alapértelmezett érték hamis "FALSE".
 
-```php config.php
+```php wp-config.php
 define( 'SCRIPT_DEBUG', true );
 ```
 
@@ -111,7 +111,7 @@ define( 'SCRIPT_DEBUG', true );
 
 A SAVEQUERIES definíció egy tömbben menti el az adatbázis-lekérdezéseket, és ezt a tömböt meg lehet jeleníteni a lekérdezések elemzéséhez. Az igaz értékre állított állandó minden lekérdezést eltárol, hogy mennyi ideig tartott a végrehajtása, és melyik függvény hívta meg.
 
-```php config.php
+```php wp-config.php
 define( 'SAVEQUERIES', true );
 ```
 
@@ -120,6 +120,30 @@ A tömb a globális `$wpdb->queries` változóban van tárolva.
 :::note
 Ez hatással lesz a webhely teljesítményére, ezért győződj meg róla, hogy kikapcsolod, amikor nem a hibakeresési folyamat része.
 :::
+
+## WP_DISABLE_FATAL_ERROR_HANDLER
+
+A WordPress 5.2 óta a rendszer beépített fatális hiba helyreállítási móddal rendelkezik. Ha fatális PHP hiba történik, a WordPress megpróbálja helyreállítani az oldalt és emailt küld az adminisztrátornak. Fejlesztés közben hasznos lehet ezt kikapcsolni, hogy a tényleges hibát lásd.
+
+```php wp-config.php
+define( 'WP_DISABLE_FATAL_ERROR_HANDLER', true );
+```
+
+## WP_DEVELOPMENT_MODE
+
+A WordPress 6.3 óta elérhető ez az állandó, amely jelzi a WordPress-nek, hogy fejlesztési módban fut. Ez befolyásolja bizonyos gyorsítótárak működését (pl. a theme.json cache kikapcsolása).
+
+```php wp-config.php
+define( 'WP_DEVELOPMENT_MODE', 'all' );
+```
+
+Lehetséges értékek:
+- `'core'` - WordPress mag fejlesztése
+- `'plugin'` - Bővítmény fejlesztése
+- `'theme'` - Sablon fejlesztése
+- `'all'` - Minden fejlesztési mód aktív
+
+A beállítás a `wp_get_development_mode()` függvénnyel lekérdezhető, így a bővítmények és sablonok is reagálhatnak rá.
 
 ## Hibakeresést segítő bővítmények
 

--- a/src/components/WPEmbed.js
+++ b/src/components/WPEmbed.js
@@ -1,40 +1,112 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
-const cache = {}; // in-memory cache
+const cache = {};
 
-function WPEmbed(props) {
-  const { url } = props;
-  const [content, setContent] = useState('');
+const htmlEntities = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#039;': "'",
+  '&#8211;': '\u2013',
+  '&#8212;': '\u2014',
+  '&#8216;': '\u2018',
+  '&#8217;': '\u2019',
+  '&#8220;': '\u201C',
+  '&#8221;': '\u201D',
+  '&nbsp;': ' ',
+};
+
+function decodeHtmlEntities(text) {
+  if (!text) return '';
+  return text.replace(/&[^;]+;/g, (match) => htmlEntities[match] || match);
+}
+
+function WPEmbed({ url }) {
+  const [plugin, setPlugin] = useState(null);
+  const [error, setError] = useState(false);
 
   useEffect(() => {
-    async function fetchContent() {
+    async function fetchPlugin() {
       try {
         if (cache[url]) {
-          // ha a tartalom már a cache-ben van, akkor visszatöltjük azt
-          setContent(cache[url]);
-        } else {
-          // különben letöltjük a tartalmat
-          const embedUrl = `https://tools.hellowp.io/wp-embed/?url=https://hu.wordpress.org/plugins/${url}/embed/`;
-          const response = await fetch(embedUrl);
-          const html = await response.text();
-          setContent(html);
-
-          // a kapott tartalmat eltároljuk a cache-ben
-          cache[url] = html;
+          setPlugin(cache[url]);
+          return;
         }
-      } catch (error) {
-        console.error(error);
+
+        const fields = [
+          'name',
+          'slug',
+          'author',
+          'rating',
+          'active_installs',
+          'short_description',
+          'icons',
+          'banners'
+        ].join(',');
+
+        const apiUrl = `https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&slug=${url}&fields=${fields}`;
+        const response = await fetch(apiUrl);
+        const data = await response.json();
+
+        if (data.error) {
+          setError(true);
+          return;
+        }
+
+        cache[url] = data;
+        setPlugin(data);
+      } catch (err) {
+        console.error(err);
+        setError(true);
       }
     }
 
-    fetchContent();
+    fetchPlugin();
   }, [url]);
 
+  if (error) {
+    return (
+      <a
+        href={`https://hu.wordpress.org/plugins/${url}/`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="wp-embed-link"
+      >
+        {url} - WordPress bővítmény
+      </a>
+    );
+  }
+
+  if (!plugin) {
+    return <div className="wp-embed-loading">Betöltés...</div>;
+  }
+
+  const icon = plugin.icons?.['2x'] || plugin.icons?.['1x'] || plugin.icons?.svg || plugin.icons?.default || null;
+  const pluginUrl = `https://hu.wordpress.org/plugins/${url}/`;
+  const name = decodeHtmlEntities(plugin.name);
+  const description = decodeHtmlEntities(plugin.short_description);
+  const author = decodeHtmlEntities(plugin.author?.replace(/<[^>]*>/g, '') || '');
+
   return (
-    <div
-      className="wp-embed"
-      dangerouslySetInnerHTML={{ __html: content }}
-    />
+    <div className="wp-embed">
+      <a href={pluginUrl} target="_blank" rel="noopener noreferrer" className="wp-embed-card">
+        {icon && (
+          <div className="wp-embed-icon">
+            <img src={icon} alt={name} />
+          </div>
+        )}
+        <div className="wp-embed-content">
+          <h4 className="wp-embed-title">{name}</h4>
+          {description && <p className="wp-embed-description">{description}</p>}
+          <div className="wp-embed-meta">
+            {author && <span className="wp-embed-author">Szerző: {author}</span>}
+            <span className="wp-embed-rating">★ {(plugin.rating / 20).toFixed(1)}</span>
+            <span className="wp-embed-downloads">{Number(plugin.active_installs).toLocaleString('hu-HU')}+ aktív telepítés</span>
+          </div>
+        </div>
+      </a>
+    </div>
   );
 }
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -363,40 +363,97 @@ html[data-theme="dark"] .try-hasura-div_QpRH .arrow_pHav path {
 
 /* WordPress embed */
 
-.wp-embed{
-  padding: 15px;
-  border-radius: 10px;
-  border:3px solid !important;
-  font-size: 16px !important;
-
+.wp-embed {
+  margin: 1rem 0;
 }
 
-html[data-theme="light"] .wp-embed{
-  border-color: #ebedf0 !important; 
+.wp-embed-card {
+  display: flex;
+  gap: 1rem;
+  padding: 1rem;
+  border-radius: 8px;
+  border: 2px solid #ebedf0;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.2s, box-shadow 0.2s;
 }
 
-html[data-theme="dark"] .wp-embed{
+.wp-embed-card:hover {
+  border-color: #3273dc;
+  box-shadow: 0 2px 8px rgba(50, 115, 220, 0.15);
+  text-decoration: none;
+  color: inherit;
+}
+
+.wp-embed-icon {
+  flex-shrink: 0;
+  width: 64px;
+  height: 64px;
+}
+
+.wp-embed-icon img {
+  width: 100%;
+  height: 100%;
+  border-radius: 8px;
+  object-fit: cover;
+}
+
+.wp-embed-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.wp-embed-title {
+  margin: 0 0 0.25rem 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #1a1a1a;
+}
+
+.wp-embed-description {
+  margin: 0 0 0.5rem 0;
+  font-size: 0.9rem;
+  color: #666;
+  line-height: 1.4;
+}
+
+.wp-embed-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.8rem;
+  color: #888;
+}
+
+.wp-embed-rating {
+  color: #ffb900;
+}
+
+.wp-embed-loading {
+  padding: 1rem;
+  color: #888;
+  font-style: italic;
+}
+
+html[data-theme="dark"] .wp-embed-card {
   background-color: #1b1b1d;
-  border-color: #444950 !important; 
+  border-color: #444950;
 }
 
-html[data-theme="dark"] .wp-embed-heading a, html[data-theme="dark"] .wp-embed-excerpt{
-color: #e3e3e3;
+html[data-theme="dark"] .wp-embed-card:hover {
+  border-color: #5a9cff;
 }
 
-.wp-embed-footer {
-  margin-top: 10px !important;
+html[data-theme="dark"] .wp-embed-title {
+  color: #e3e3e3;
 }
 
-.plugin-download.button.download-button.button-large{
-  background-color: #3273dc !important;
-  border: none;
-  box-shadow: none;
-  text-shadow: none !important;
+html[data-theme="dark"] .wp-embed-description {
+  color: #aaa;
 }
 
-.plugin-download.button.download-button.button-large:hover{
-  background-color: #2b62bb !important;
+html[data-theme="dark"] .wp-embed-meta {
+  color: #888;
 }
 
 /* Content slider */


### PR DESCRIPTION
## Summary

- **WPEmbed komponens újraírása**: A komponens mostantól közvetlenül a WordPress.org API-t használja a `tools.hellowp.io` proxy helyett
- **Új CSS stílusok**: Plugin kártyák megjelenítése light/dark mode támogatással
- **Hibakeresési dokumentáció frissítése**:
  - `WP_DISABLE_FATAL_ERROR_HANDLER` (WP 5.2+) szekció hozzáadva
  - `WP_DEVELOPMENT_MODE` (WP 6.3+) szekció hozzáadva
  - "Happy blogging" → "Happy publishing" javítás
  - `config.php` → `wp-config.php` javítás a kódblokkokban
  - Nyelvtani hiba javítása ("az hibákról" → "a hibákról")

## Test plan

- [ ] WPEmbed komponens renderelésének ellenőrzése a hibakeresési oldalon
- [ ] Light/dark mode megjelenés tesztelése
- [ ] Plugin adatok (ikon, név, leírás, értékelés) megjelenésének ellenőrzése