### PR TITLE
fix: use public npm registry for @fortawesome packages

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@fortawesome:registry=https://registry.npmjs.org/

--- a/package-lock.json
+++ b/package-lock.json
@@ -4026,7 +4026,7 @@
     },
     "node_modules/@fortawesome/fontawesome-common-types": {
       "version": "6.7.2",
-      "resolved": "https://npm.fontawesome.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
       "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
       "license": "MIT",
       "engines": {
@@ -4035,7 +4035,7 @@
     },
     "node_modules/@fortawesome/fontawesome-svg-core": {
       "version": "6.7.2",
-      "resolved": "https://npm.fontawesome.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
       "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
A lockfile-ban a FontAwesome csomagok resolved URL-jei a Pro registry-re (npm.fontawesome.com) mutattak, ami a build env-ben E401-et dobott token hiányában. A package.json csak Free csomagokat használ, ezért:

- `.npmrc` projekt szintű scope override a public registry-re
- lockfile resolved URL-ek public npm-re átírva