### PR TITLE
fix: MDX parsing error and broken docs links

### DIFF
--- a/docs/dokumentacio/hellohost/fejlesztoknek/vscode-remote-ssh.mdx
+++ b/docs/dokumentacio/hellohost/fejlesztoknek/vscode-remote-ssh.mdx
@@ -53,7 +53,7 @@ Alternatíva CLI-ből:
 code --install-extension ms-vscode-remote.remote-ssh
 ```
 
-Felvesz egy **Remote Explorer** ikont a bal oldali sávba (monitor + kis kör), és egy **zöld "><" gombot** a bal alsó sarokba.
+Felvesz egy **Remote Explorer** ikont a bal oldali sávba (monitor + kis kör), és egy **zöld `><` gombot** a bal alsó sarokba.
 
 ## Csatlakozás HelloHost szerverhez
 

--- a/docs/dokumentacio/hellohost/index.mdx
+++ b/docs/dokumentacio/hellohost/index.mdx
@@ -31,6 +31,6 @@ A HelloHost a mi menedzselt WordPress tárhely és szerverkezelő platformunk. E
 
 ## Kapcsolódó eszközök
 
-- **[HelloPack](/dokumentacio/hellopack)** – prémium bővítmény/téma kezelés a HelloHoston futó site-okhoz
-- **[HelloTools](/dokumentacio/hellotools)** – fejlesztői segédeszközök
-- **[MailHub](/dokumentacio/mailhub)** – email kiszolgáló konfiguráció
+- **[HelloPack](/docs/dokumentacio/hellopack)** – prémium bővítmény/téma kezelés a HelloHoston futó site-okhoz
+- **[HelloTools](/docs/dokumentacio/hellotools)** – fejlesztői segédeszközök
+- **[MailHub](/docs/dokumentacio/mailhub)** – email kiszolgáló konfiguráció


### PR DESCRIPTION
- `vscode-remote-ssh.mdx`: `><` inline code-ba téve, mert az MDX3 parser JSX tag-nek értelmezte az idézőjelek közötti `<` karaktert
- `hellohost/index.mdx`: hiányzó `/docs` prefix a kapcsolódó eszköz linkeknél (HelloPack, HelloTools, MailHub)